### PR TITLE
Enable loading resume data from a url

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "js-yaml": "^3.12.0",
+    "query-string": "^6.1.0",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "react-monaco-editor": "^0.18.0",

--- a/src/containers/AppContainer.tsx
+++ b/src/containers/AppContainer.tsx
@@ -9,7 +9,7 @@ import Swipe from 'containers/Swipe';
 import Hint from '../components/Hint';
 
 interface AppProps {
-  sampleResumeUrl: string;
+  resumeUrl: string;
 }
 
 interface AppState {
@@ -141,7 +141,7 @@ class AppContainer extends React.Component<AppProps, AppState> {
   };
 
   private loadInitialData() {
-    getInitialYamlData({ sampleResumeUrl: this.props.sampleResumeUrl }).then(
+    getInitialYamlData({ url: this.props.resumeUrl }).then(
       yamlData => {
         this.setState({ yamlData });
       }

--- a/src/containers/AppContainer.tsx
+++ b/src/containers/AppContainer.tsx
@@ -10,6 +10,7 @@ import Hint from '../components/Hint';
 
 interface AppProps {
   resumeUrl: string;
+  useLocal?: boolean;
 }
 
 interface AppState {
@@ -23,6 +24,10 @@ interface AppState {
 }
 
 class AppContainer extends React.Component<AppProps, AppState> {
+  static defaultProps: Partial<AppProps> = {
+    useLocal: true
+  };
+
   state = {
     yamlData: '',
     resizing: false,
@@ -141,11 +146,12 @@ class AppContainer extends React.Component<AppProps, AppState> {
   };
 
   private loadInitialData() {
-    getInitialYamlData({ url: this.props.resumeUrl }).then(
-      yamlData => {
-        this.setState({ yamlData });
-      }
-    );
+    getInitialYamlData({
+      url: this.props.resumeUrl,
+      useLocal: this.props.useLocal
+    }).then(yamlData => {
+      this.setState({ yamlData });
+    });
   }
 
   private setEditorVisibility(showEditor: boolean) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,4 +15,5 @@ ReactDOM.render(
   />,
   document.getElementById('root')
 );
+
 registerServiceWorker();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,7 @@ const resumeUrl = parse(window.location.search.slice(1)).src as
 ReactDOM.render(
   <AppContainer
     resumeUrl={resumeUrl || `${process.env.PUBLIC_URL}/resume.yaml`}
+    useLocal={!resumeUrl}
   />,
   document.getElementById('root')
 );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,9 +3,14 @@ import * as ReactDOM from 'react-dom';
 import registerServiceWorker from 'registerServiceWorker';
 import AppContainer from 'containers/AppContainer';
 import 'styles/index.css';
+import { parse } from 'querystring';
+
+const resumeUrl = parse(window.location.search).src as string | undefined;
 
 ReactDOM.render(
-  <AppContainer resumeUrl={`${process.env.PUBLIC_URL}/resume.yaml`} />,
+  <AppContainer
+    resumeUrl={resumeUrl || `${process.env.PUBLIC_URL}/resume.yaml`}
+  />,
   document.getElementById('root')
 );
 registerServiceWorker();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,9 @@ import AppContainer from 'containers/AppContainer';
 import 'styles/index.css';
 import { parse } from 'querystring';
 
-const resumeUrl = parse(window.location.search).src as string | undefined;
+const resumeUrl = parse(window.location.search.slice(1)).src as
+  | string
+  | undefined;
 
 ReactDOM.render(
   <AppContainer

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,7 @@ import AppContainer from 'containers/AppContainer';
 import 'styles/index.css';
 
 ReactDOM.render(
-  <AppContainer sampleResumeUrl={`${process.env.PUBLIC_URL}/resume.yaml`} />,
+  <AppContainer resumeUrl={`${process.env.PUBLIC_URL}/resume.yaml`} />,
   document.getElementById('root')
 );
 registerServiceWorker();

--- a/src/utils/getInitialYamlData.ts
+++ b/src/utils/getInitialYamlData.ts
@@ -1,5 +1,11 @@
-const getInitialYamlData = async ({ url }: { url: string }) =>
-  window.localStorage.getItem('resumae') ||
+const getInitialYamlData = async ({
+  url,
+  useLocal
+}: {
+  url: string;
+  useLocal?: boolean;
+}) =>
+  (useLocal && window.localStorage.getItem('resumae')) ||
   (await fetch(url).then(res => res.text()));
 
 export default getInitialYamlData;

--- a/src/utils/getInitialYamlData.ts
+++ b/src/utils/getInitialYamlData.ts
@@ -1,9 +1,5 @@
-const getInitialYamlData = async ({
-  sampleResumeUrl
-}: {
-  sampleResumeUrl: string;
-}) =>
+const getInitialYamlData = async ({ url }: { url: string }) =>
   window.localStorage.getItem('resumae') ||
-  (await fetch(sampleResumeUrl).then(res => res.text()));
+  (await fetch(url).then(res => res.text()));
 
 export default getInitialYamlData;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5714,6 +5714,13 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.1.0.tgz#01e7d69f6a0940dac67a937d6c6325647aa4532a"
+  dependencies:
+    decode-uri-component "^0.2.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -6665,6 +6672,10 @@ stream-shift@^1.0.0:
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
From now on you can load any resume, not just the sample or whatever is stored within your local storage. Just use the following syntax in your browser's address bar: `url-to-app/?src=url-to-yaml`, e.g.:
```
https://jacekwilczynski.github.io/resumae/?src=https://johnsmith3456.github.io/resume.yaml
```

fixes #2 